### PR TITLE
makes build for usage as library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,24 @@
 {
   "name": "vue2-boring-avatars",
-  "description":  "Vue2 port of boring avatars",
+  "description": "Vue2 port of boring avatars",
   "version": "0.2.1",
   "homepage": "https://github.com/stonega/vue2-boring-avatars",
   "license": "GPL V3",
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build --target lib --name vue-2-boring-avatars --entry src/index.js",
     "lint": "vue-cli-service lint"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/vue-boring-avatars.umd.js",
+  "module": "./dist/vue-boring-avatars.es.js",
+  "exports": {
+    ".": {
+      "import": "./dist/vue-2-boring-avatars.es.js",
+      "require": "./dist/vue-2-boring-avatars.umd.js"
+    }
   },
   "dependencies": {
     "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "vue2-boring-avatars",
+  "name": "@schpnpls/vue2-boring-avatars",
   "description": "Vue2 port of boring avatars",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "homepage": "https://github.com/stonega/vue2-boring-avatars",
-  "license": "GPL V3",
+  "license": "GPL v3",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --target lib --name vue-2-boring-avatars --entry src/index.js",
@@ -52,5 +52,13 @@
     "> 1%",
     "last 2 versions",
     "not dead"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agustif/nuxt-boring-avatars.git"
+  },
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/agustif/nuxt-boring-avatars/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@schpnpls/vue2-boring-avatars",
   "description": "Vue2 port of boring avatars",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/stonega/vue2-boring-avatars",
   "license": "GPL v3",
   "scripts": {
@@ -12,8 +12,8 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/vue-boring-avatars.umd.js",
-  "module": "./dist/vue-boring-avatars.es.js",
+  "main": "./dist/vue-2-boring-avatars.umd.js",
+  "module": "./dist/vue-2-boring-avatars.es.js",
   "exports": {
     ".": {
       "import": "./dist/vue-2-boring-avatars.es.js",


### PR DESCRIPTION
Hello!

Hope this can get merged, makes the library usable as npm package by default by building to dist folder and making files available as exports/main

Thanks for sharing!

closes #1 