### PR TITLE
Remove <main> element from Avatar.vue

### DIFF
--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,21 +1,16 @@
 <template>
-    <component
-      :is="componentName"
-      :name="name"
-      :colors="colors"
-      :size="size"
-    />
+  <component :is="componentName" :name="name" :colors="colors" :size="size" />
 </template>
 
 <script>
-import AvatarPixels from "./AvatarPixels";
-import AvatarBauhaus from "./AvatarBauhaus";
-import AvatarMarble from "./AvatarMarble";
-import AvatarRing from "./AvatarRing";
-import AvatarSunset from "./AvatarSunset";
-import AvatarBeam from "./AvatarBeam";
+import AvatarPixels from './AvatarPixels'
+import AvatarBauhaus from './AvatarBauhaus'
+import AvatarMarble from './AvatarMarble'
+import AvatarRing from './AvatarRing'
+import AvatarSunset from './AvatarSunset'
+import AvatarBeam from './AvatarBeam'
 
-const VARIANTS = ["pixels", "bauhaus", "ring", "beam", "sunset", "marble"];
+const VARIANTS = ['pixels', 'bauhaus', 'ring', 'beam', 'sunset', 'marble']
 
 export default {
   components: {
@@ -24,29 +19,30 @@ export default {
     AvatarMarble,
     AvatarSunset,
     AvatarRing,
-    AvatarBeam,
+    AvatarBeam
   },
   props: {
     variant: {
       type: String,
-      default: "pixels",
-      validator: function (value) {
-        return VARIANTS.indexOf(value) !== -1;
-      },
+      default: 'pixels',
+      validator(value) {
+        return VARIANTS.includes(value)
+      }
     },
-    name: { type: String, default: "Mary Baker" },
+    name: { type: String, default: 'Mary Baker' },
     colors: {
       type: Array,
-      default: () => ["#92A1C6", "#146A7C", "#F0AB3D", "#C271B4", "#C20D90"],
+      default: () => ['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90']
     },
-    size: { type: Number, default: 80 },
+    size: { type: Number, default: 80 }
   },
-  computed:{
-    componentName(){
-      if(VARIANTS.indexOf(this.variant) === -1){
-        return 'avatar-pixels';
+  computed: {
+    componentName() {
+      if (!VARIANTS.includes(this.variant)) {
+        return 'avatar-pixels'
       }
-      return 'avatar-'+this.variant;
+      return 'avatar-' + this.variant
     }
-};
+  }
+}
 </script>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,42 +1,10 @@
 <template>
-  <main>
-    <avatar-pixels
-      v-if="variant === 'pixels'"
+    <component
+      :is="componentName"
       :name="name"
       :colors="colors"
       :size="size"
     />
-    <avatar-bauhaus
-      v-if="variant === 'bauhaus'"
-      :name="name"
-      :colors="colors"
-      :size="size"
-    />
-    <avatar-marble
-      v-if="variant === 'marble'"
-      :name="name"
-      :colors="colors"
-      :size="size"
-    />
-    <avatar-ring
-      v-if="variant === 'ring'"
-      :name="name"
-      :colors="colors"
-      :size="size"
-    />
-    <avatar-sunset
-      v-if="variant === 'sunset'"
-      :name="name"
-      :colors="colors"
-      :size="size"
-    />
-    <avatar-beam
-      v-if="variant === 'beam'"
-      :name="name"
-      :colors="colors"
-      :size="size"
-    />
-  </main>
 </template>
 
 <script>
@@ -73,10 +41,12 @@ export default {
     },
     size: { type: Number, default: 80 },
   },
-  data() {
-    return {
-      variants: VARIANTS,
-    };
-  },
+  computed:{
+    componentName(){
+      if(VARIANTS.indexOf(this.variant) === -1){
+        return 'avatar-pixels';
+      }
+      return 'avatar-'+this.variant;
+    }
 };
 </script>


### PR DESCRIPTION
Per [MDN](https://developer.mozilla.org/en-US/docs/web/html/element/main)

> A document mustn't have more than one `<main>` element that doesn't have the hidden attribute specified.

This PR removes the `<main>` element from `Avatar.vue` and brings it more inline with what the Vue 3 Boring Avatars variant is doing with a single `<component is="">` component inside. 

https://github.com/mujahidfa/vue-boring-avatars/blob/master/src/components/Avatar.vue#L1-L9 